### PR TITLE
Set the logger globally in LogListenAndServe func

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -108,7 +108,7 @@ var (
 // LogListenAndServe logs using the logger and then calls ListenAndServe
 func LogListenAndServe(s Server, loggers ...Logger) {
 	if hs, ok := s.(*http.Server); ok {
-		logger := getLogger(loggers...)
+		logger = getLogger(loggers...)
 		logger.Printf(ListeningFormat, hs.Addr)
 	}
 


### PR DESCRIPTION
Looking at your documentation for your `LogListenAndServe` usage, you expect the following output for the provided example:

```
go run main.go
Listening on http://0.0.0.0:2017
^C
Server shutdown with timeout: 15s
Finished all in-flight HTTP requests
Shutdown finished 14s before deadline
```

Without this adjustment, we only get this output:

```
go run main.go
Listening on http://0.0.0.0:2017
^C
```

p.s. Nice lib!  Was looking for something exactly like this after go 1.8 to replace my `tylerb/graceful` usage.