### PR TITLE
Fix package doc

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -1,6 +1,6 @@
 /*
 
-Package graceful simplifies graceful shutdown of HTTP servers (Go 1.8+)
+Package graceful simplifies graceful shutdown of HTTP servers (Go 1.8+).
 
 Installation
 


### PR DESCRIPTION
Add final point to the package documentation summary so godoc properly stops after the first sentence.

Here is how to reproduce the issue:
```
go list -f '{{.Doc}}' github.com/TV4/graceful
```